### PR TITLE
Renamed mpn to partName

### DIFF
--- a/csharp-app/Search/Stubs/parts.json
+++ b/csharp-app/Search/Stubs/parts.json
@@ -3,7 +3,7 @@
     {
       "part": {
         "id": "38945990",
-        "mpn": "ACS770ECB-200U-PFF-T",
+        "partName": "ACS770ECB-200U-PFF-T",
         "sellers": [
           {
             "company": {
@@ -102,7 +102,7 @@
     {
       "part": {
         "id": "14377977",
-        "mpn": "RMD-53-66",
+        "partName": "RMD-53-66",
         "sellers": [
           {
             "company": {
@@ -176,7 +176,7 @@
     {
       "part": {
         "id": "82828282",
-        "mpn": "RN42XVP-IRM",
+        "partName": "RN42XVP-IRM",
         "sellers": [
           {
             "company": {

--- a/go-app/utils/jsondata.go
+++ b/go-app/utils/jsondata.go
@@ -8,7 +8,7 @@ func PartOffers() []byte {
     {
       "part": {
         "id": "38945990",
-        "mpn": "ACS770ECB-200U-PFF-T",
+        "partName": "ACS770ECB-200U-PFF-T",
         "sellers": [
           {
             "company": {
@@ -107,7 +107,7 @@ func PartOffers() []byte {
     {
       "part": {
         "id": "14377977",
-        "mpn": "RMD-53-66",
+        "partName": "RMD-53-66",
         "sellers": [
           {
             "company": {
@@ -181,7 +181,7 @@ func PartOffers() []byte {
     {
       "part": {
         "id": "82828282",
-        "mpn": "RN42XVP-IRM",
+        "partName": "RN42XVP-IRM",
         "sellers": [
           {
             "company": {

--- a/python-app/utils/jsondata.py
+++ b/python-app/utils/jsondata.py
@@ -8,7 +8,7 @@ def part_offers():
     {
       "part": {
         "id": "38945990",
-        "mpn": "ACS770ECB-200U-PFF-T",
+        "partName": "ACS770ECB-200U-PFF-T",
         "sellers": [
           {
             "company": {
@@ -107,7 +107,7 @@ def part_offers():
     {
       "part": {
         "id": "14377977",
-        "mpn": "RMD-53-66",
+        "partName": "RMD-53-66",
         "sellers": [
           {
             "company": {
@@ -181,7 +181,7 @@ def part_offers():
     {
       "part": {
         "id": "82828282",
-        "mpn": "RN42XVP-IRM",
+        "partName": "RN42XVP-IRM",
         "sellers": [
           {
             "company": {
@@ -216,5 +216,4 @@ def part_offers():
   ]
 }
     '''
-    print(data)
     return data


### PR DESCRIPTION
The text uses `partName` instead of `mpn`